### PR TITLE
Update minimum cmake version to 3.16 and update expected header

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,8 +27,7 @@
 #   -DCMAKE_BUILD_TYPE=type
 # to the cmake call.
 
-# Version 2.8.3 introduces CMakeParseArguments.
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.16)
 
 # Respect the PATH environment variable when searching for compilers.
 find_program(CMAKE_C_COMPILER NAMES $ENV{CC} gcc PATHS ENV PATH NO_DEFAULT_PATH)

--- a/src/search/CMakeLists.txt
+++ b/src/search/CMakeLists.txt
@@ -1,6 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
-# For Windows we require CMake 3.12, but this is currently not
-# available for Ubuntu 18.04.
+cmake_minimum_required(VERSION 3.16)
 
 if(NOT FAST_DOWNWARD_MAIN_CMAKELISTS_READ)
     message(

--- a/src/search/ext/optional.hh
+++ b/src/search/ext/optional.hh
@@ -1,6 +1,9 @@
-//
+
+///
 // optional - An implementation of std::optional with extensions
-// Written in 2017 by Simon Brand (tartanllama@gmail.com, @TartanLlama)
+// Written in 2017 by Sy Brand (tartanllama@gmail.com, @TartanLlama)
+//
+// Documentation available at https://tl.tartanllama.xyz/
 //
 // To the extent possible under law, the author(s) have dedicated all
 // copyright and related and neighboring rights to this software to the
@@ -14,8 +17,9 @@
 #ifndef TL_OPTIONAL_HPP
 #define TL_OPTIONAL_HPP
 
-#define TL_OPTIONAL_VERSION_MAJOR 0
-#define TL_OPTIONAL_VERSION_MINOR 5
+#define TL_OPTIONAL_VERSION_MAJOR 1
+#define TL_OPTIONAL_VERSION_MINOR 1
+#define TL_OPTIONAL_VERSION_PATCH 0
 
 #include <exception>
 #include <functional>
@@ -69,7 +73,7 @@ namespace tl {
       template<class T, class A>
       struct is_trivially_copy_constructible<std::vector<T,A>>
           : std::is_trivially_copy_constructible<T>{};
-#endif
+#endif      
   }
 }
 #endif
@@ -94,30 +98,27 @@ namespace tl {
 // constexpr implies const in C++11, not C++14
 #if (__cplusplus == 201103L || defined(TL_OPTIONAL_MSVC2015) ||                \
      defined(TL_OPTIONAL_GCC49))
-/// \exclude
 #define TL_OPTIONAL_11_CONSTEXPR
 #else
-/// \exclude
 #define TL_OPTIONAL_11_CONSTEXPR constexpr
 #endif
 
 namespace tl {
 #ifndef TL_MONOSTATE_INPLACE_MUTEX
 #define TL_MONOSTATE_INPLACE_MUTEX
-/// \brief Used to represent an optional with no data; essentially a bool
+/// Used to represent an optional with no data; essentially a bool
 class monostate {};
 
-/// \brief A tag type to tell optional to construct its value in-place
+///  A tag type to tell optional to construct its value in-place
 struct in_place_t {
   explicit in_place_t() = default;
 };
-/// \brief A tag to tell optional to construct its value in-place
+/// A tag to tell optional to construct its value in-place
 static constexpr in_place_t in_place{};
 #endif
 
 template <class T> class optional;
 
-/// \exclude
 namespace detail {
 #ifndef TL_TRAITS_MUTEX
 #define TL_TRAITS_MUTEX
@@ -139,38 +140,38 @@ struct conjunction<B, Bs...>
     : std::conditional<bool(B::value), conjunction<Bs...>, B>::type {};
 
 #if defined(_LIBCPP_VERSION) && __cplusplus == 201103L
-#define TL_OPTIONAL_LIBCXX_MEM_FN_WORKAROUND
+#define TL_TRAITS_LIBCXX_MEM_FN_WORKAROUND
 #endif
 
 // In C++11 mode, there's an issue in libc++'s std::mem_fn
 // which results in a hard-error when using it in a noexcept expression
 // in some cases. This is a check to workaround the common failing case.
-#ifdef TL_OPTIONAL_LIBCXX_MEM_FN_WORKAROUND
+#ifdef TL_TRAITS_LIBCXX_MEM_FN_WORKAROUND
 template <class T> struct is_pointer_to_non_const_member_func : std::false_type{};
 template <class T, class Ret, class... Args>
 struct is_pointer_to_non_const_member_func<Ret (T::*) (Args...)> : std::true_type{};
 template <class T, class Ret, class... Args>
 struct is_pointer_to_non_const_member_func<Ret (T::*) (Args...)&> : std::true_type{};
 template <class T, class Ret, class... Args>
-struct is_pointer_to_non_const_member_func<Ret (T::*) (Args...)&&> : std::true_type{};
+struct is_pointer_to_non_const_member_func<Ret (T::*) (Args...)&&> : std::true_type{};        
 template <class T, class Ret, class... Args>
 struct is_pointer_to_non_const_member_func<Ret (T::*) (Args...) volatile> : std::true_type{};
 template <class T, class Ret, class... Args>
 struct is_pointer_to_non_const_member_func<Ret (T::*) (Args...) volatile&> : std::true_type{};
 template <class T, class Ret, class... Args>
-struct is_pointer_to_non_const_member_func<Ret (T::*) (Args...) volatile&&> : std::true_type{};
+struct is_pointer_to_non_const_member_func<Ret (T::*) (Args...) volatile&&> : std::true_type{};        
 
 template <class T> struct is_const_or_const_ref : std::false_type{};
 template <class T> struct is_const_or_const_ref<T const&> : std::true_type{};
-template <class T> struct is_const_or_const_ref<T const> : std::true_type{};
+template <class T> struct is_const_or_const_ref<T const> : std::true_type{};    
 #endif
 
 // std::invoke from C++17
 // https://stackoverflow.com/questions/38288042/c11-14-invoke-workaround
 template <typename Fn, typename... Args,
-#ifdef TL_OPTIONAL_LIBCXX_MEM_FN_WORKAROUND
-          typename = enable_if_t<!(is_pointer_to_non_const_member_func<Fn>::value
-                                 && is_const_or_const_ref<Args...>::value)>,
+#ifdef TL_TRAITS_LIBCXX_MEM_FN_WORKAROUND
+          typename = enable_if_t<!(is_pointer_to_non_const_member_func<Fn>::value 
+                                 && is_const_or_const_ref<Args...>::value)>, 
 #endif
           typename = enable_if_t<std::is_member_pointer<decay_t<Fn>>::value>,
           int = 0>
@@ -203,6 +204,79 @@ using invoke_result = invoke_result_impl<F, void, Us...>;
 
 template <class F, class... Us>
 using invoke_result_t = typename invoke_result<F, Us...>::type;
+
+#if defined(_MSC_VER) && _MSC_VER <= 1900
+// TODO make a version which works with MSVC 2015
+template <class T, class U = T> struct is_swappable : std::true_type {};
+
+template <class T, class U = T> struct is_nothrow_swappable : std::true_type {};
+#else
+// https://stackoverflow.com/questions/26744589/what-is-a-proper-way-to-implement-is-swappable-to-test-for-the-swappable-concept
+namespace swap_adl_tests {
+// if swap ADL finds this then it would call std::swap otherwise (same
+// signature)
+struct tag {};
+
+template <class T> tag swap(T &, T &);
+template <class T, std::size_t N> tag swap(T (&a)[N], T (&b)[N]);
+
+// helper functions to test if an unqualified swap is possible, and if it
+// becomes std::swap
+template <class, class> std::false_type can_swap(...) noexcept(false);
+template <class T, class U,
+          class = decltype(swap(std::declval<T &>(), std::declval<U &>()))>
+std::true_type can_swap(int) noexcept(noexcept(swap(std::declval<T &>(),
+                                                    std::declval<U &>())));
+
+template <class, class> std::false_type uses_std(...);
+template <class T, class U>
+std::is_same<decltype(swap(std::declval<T &>(), std::declval<U &>())), tag>
+uses_std(int);
+
+template <class T>
+struct is_std_swap_noexcept
+    : std::integral_constant<bool,
+                             std::is_nothrow_move_constructible<T>::value &&
+                                 std::is_nothrow_move_assignable<T>::value> {};
+
+template <class T, std::size_t N>
+struct is_std_swap_noexcept<T[N]> : is_std_swap_noexcept<T> {};
+
+template <class T, class U>
+struct is_adl_swap_noexcept
+    : std::integral_constant<bool, noexcept(can_swap<T, U>(0))> {};
+} // namespace swap_adl_tests
+
+template <class T, class U = T>
+struct is_swappable
+    : std::integral_constant<
+          bool,
+          decltype(detail::swap_adl_tests::can_swap<T, U>(0))::value &&
+              (!decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value ||
+               (std::is_move_assignable<T>::value &&
+                std::is_move_constructible<T>::value))> {};
+
+template <class T, std::size_t N>
+struct is_swappable<T[N], T[N]>
+    : std::integral_constant<
+          bool,
+          decltype(detail::swap_adl_tests::can_swap<T[N], T[N]>(0))::value &&
+              (!decltype(
+                   detail::swap_adl_tests::uses_std<T[N], T[N]>(0))::value ||
+               is_swappable<T, T>::value)> {};
+
+template <class T, class U = T>
+struct is_nothrow_swappable
+    : std::integral_constant<
+          bool,
+          is_swappable<T, U>::value &&
+              ((decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value
+                    &&detail::swap_adl_tests::is_std_swap_noexcept<T>::value) ||
+               (!decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value &&
+                    detail::swap_adl_tests::is_adl_swap_noexcept<T,
+                                                                 U>::value))> {
+};
+#endif
 #endif
 
 // std::void_t from C++17
@@ -277,79 +351,6 @@ using enable_assign_from_other = detail::enable_if_t<
     !std::is_assignable<T &, const optional<U> &>::value &&
     !std::is_assignable<T &, const optional<U> &&>::value>;
 
-#ifdef _MSC_VER
-// TODO make a version which works with MSVC
-template <class T, class U = T> struct is_swappable : std::true_type {};
-
-template <class T, class U = T> struct is_nothrow_swappable : std::true_type {};
-#else
-// https://stackoverflow.com/questions/26744589/what-is-a-proper-way-to-implement-is-swappable-to-test-for-the-swappable-concept
-namespace swap_adl_tests {
-// if swap ADL finds this then it would call std::swap otherwise (same
-// signature)
-struct tag {};
-
-template <class T> tag swap(T &, T &);
-template <class T, std::size_t N> tag swap(T (&a)[N], T (&b)[N]);
-
-// helper functions to test if an unqualified swap is possible, and if it
-// becomes std::swap
-template <class, class> std::false_type can_swap(...) noexcept(false);
-template <class T, class U,
-          class = decltype(swap(std::declval<T &>(), std::declval<U &>()))>
-std::true_type can_swap(int) noexcept(noexcept(swap(std::declval<T &>(),
-                                                    std::declval<U &>())));
-
-template <class, class> std::false_type uses_std(...);
-template <class T, class U>
-std::is_same<decltype(swap(std::declval<T &>(), std::declval<U &>())), tag>
-uses_std(int);
-
-template <class T>
-struct is_std_swap_noexcept
-    : std::integral_constant<bool,
-                             std::is_nothrow_move_constructible<T>::value &&
-                                 std::is_nothrow_move_assignable<T>::value> {};
-
-template <class T, std::size_t N>
-struct is_std_swap_noexcept<T[N]> : is_std_swap_noexcept<T> {};
-
-template <class T, class U>
-struct is_adl_swap_noexcept
-    : std::integral_constant<bool, noexcept(can_swap<T, U>(0))> {};
-} // namespace swap_adl_tests
-
-template <class T, class U = T>
-struct is_swappable
-    : std::integral_constant<
-          bool,
-          decltype(detail::swap_adl_tests::can_swap<T, U>(0))::value &&
-              (!decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value ||
-               (std::is_move_assignable<T>::value &&
-                std::is_move_constructible<T>::value))> {};
-
-template <class T, std::size_t N>
-struct is_swappable<T[N], T[N]>
-    : std::integral_constant<
-          bool,
-          decltype(detail::swap_adl_tests::can_swap<T[N], T[N]>(0))::value &&
-              (!decltype(
-                   detail::swap_adl_tests::uses_std<T[N], T[N]>(0))::value ||
-               is_swappable<T, T>::value)> {};
-
-template <class T, class U = T>
-struct is_nothrow_swappable
-    : std::integral_constant<
-          bool,
-          is_swappable<T, U>::value &&
-              ((decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value
-                    &&detail::swap_adl_tests::is_std_swap_noexcept<T>::value) ||
-               (!decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value &&
-                    detail::swap_adl_tests::is_adl_swap_noexcept<T,
-                                                                 U>::value))> {
-};
-#endif
-
 // The storage base manages the actual storage, and correctly propagates
 // trivial destruction from T. This case is for when T is not trivially
 // destructible.
@@ -408,7 +409,7 @@ template <class T> struct optional_operations_base : optional_storage_base<T> {
     this->m_has_value = false;
   }
 
-  template <class... Args> void construct(Args &&... args) noexcept {
+  template <class... Args> void construct(Args &&... args) {
     new (std::addressof(this->m_value)) T(std::forward<Args>(args)...);
     this->m_has_value = true;
   }
@@ -451,7 +452,8 @@ struct optional_copy_base<T, false> : optional_operations_base<T> {
   using optional_operations_base<T>::optional_operations_base;
 
   optional_copy_base() = default;
-  optional_copy_base(const optional_copy_base &rhs) {
+  optional_copy_base(const optional_copy_base &rhs)
+  : optional_operations_base<T>() {
     if (rhs.has_value()) {
       this->construct(rhs.get());
     } else {
@@ -653,20 +655,12 @@ template <class T> struct optional_delete_assign_base<T, false, false> {
 
 } // namespace detail
 
-/// \brief A tag type to represent an empty optional
+/// A tag type to represent an empty optional
 struct nullopt_t {
   struct do_not_use {};
   constexpr explicit nullopt_t(do_not_use, do_not_use) noexcept {}
 };
-/// \brief Represents an empty optional
-/// \synopsis static constexpr nullopt_t nullopt;
-///
-/// *Examples*:
-/// ```
-/// tl::optional<int> a = tl::nullopt;
-/// void foo (tl::optional<int>);
-/// foo(tl::nullopt); //pass an empty optional
-/// ```
+/// Represents an empty optional
 static constexpr nullopt_t nullopt{nullopt_t::do_not_use{},
                                    nullopt_t::do_not_use{}};
 
@@ -700,16 +694,8 @@ public:
 // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0826r0.html
 #if defined(TL_OPTIONAL_CXX14) && !defined(TL_OPTIONAL_GCC49) &&               \
     !defined(TL_OPTIONAL_GCC54) && !defined(TL_OPTIONAL_GCC55)
-  /// \group and_then
   /// Carries out some operation which returns an optional on the stored
-  /// object if there is one. \requires `std::invoke(std::forward<F>(f),
-  /// value())` returns a `std::optional<U>` for some `U`. \returns Let `U` be
-  /// the result of `std::invoke(std::forward<F>(f), value())`. Returns a
-  /// `std::optional<U>`. The return value is empty if `*this` is empty,
-  /// otherwise the return value of `std::invoke(std::forward<F>(f), value())`
-  /// is returned.
-  /// \group and_then
-  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) &;
+  /// object if there is one.
   template <class F> TL_OPTIONAL_11_CONSTEXPR auto and_then(F &&f) & {
     using result = detail::invoke_result_t<F, T &>;
     static_assert(detail::is_optional<result>::value,
@@ -719,8 +705,6 @@ public:
                        : result(nullopt);
   }
 
-  /// \group and_then
-  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) &&;
   template <class F> TL_OPTIONAL_11_CONSTEXPR auto and_then(F &&f) && {
     using result = detail::invoke_result_t<F, T &&>;
     static_assert(detail::is_optional<result>::value,
@@ -730,8 +714,6 @@ public:
                        : result(nullopt);
   }
 
-  /// \group and_then
-  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) const &;
   template <class F> constexpr auto and_then(F &&f) const & {
     using result = detail::invoke_result_t<F, const T &>;
     static_assert(detail::is_optional<result>::value,
@@ -742,8 +724,6 @@ public:
   }
 
 #ifndef TL_OPTIONAL_NO_CONSTRR
-  /// \group and_then
-  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) const &&;
   template <class F> constexpr auto and_then(F &&f) const && {
     using result = detail::invoke_result_t<F, const T &&>;
     static_assert(detail::is_optional<result>::value,
@@ -754,28 +734,17 @@ public:
   }
 #endif
 #else
-  /// \group and_then
   /// Carries out some operation which returns an optional on the stored
-  /// object if there is one. \requires `std::invoke(std::forward<F>(f),
-  /// value())` returns a `std::optional<U>` for some `U`.
-  /// \returns Let `U` be the result of `std::invoke(std::forward<F>(f),
-  /// value())`. Returns a `std::optional<U>`. The return value is empty if
-  /// `*this` is empty, otherwise the return value of
-  /// `std::invoke(std::forward<F>(f), value())` is returned.
-  /// \group and_then
-  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) &;
+  /// object if there is one.
   template <class F>
   TL_OPTIONAL_11_CONSTEXPR detail::invoke_result_t<F, T &> and_then(F &&f) & {
     using result = detail::invoke_result_t<F, T &>;
     static_assert(detail::is_optional<result>::value,
                   "F must return an optional");
 
-    return has_value() ? detail::invoke(std::forward<F>(f), **this)
-                       : result(nullopt);
+    return has_value() ? detail::invoke(std::forward<F>(f), **this) : result(nullopt);
   }
 
-  /// \group and_then
-  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) &&;
   template <class F>
   TL_OPTIONAL_11_CONSTEXPR detail::invoke_result_t<F, T &&> and_then(F &&f) && {
     using result = detail::invoke_result_t<F, T &&>;
@@ -786,8 +755,6 @@ public:
                        : result(nullopt);
   }
 
-  /// \group and_then
-  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) const &;
   template <class F>
   constexpr detail::invoke_result_t<F, const T &> and_then(F &&f) const & {
     using result = detail::invoke_result_t<F, const T &>;
@@ -799,8 +766,6 @@ public:
   }
 
 #ifndef TL_OPTIONAL_NO_CONSTRR
-  /// \group and_then
-  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) const &&;
   template <class F>
   constexpr detail::invoke_result_t<F, const T &&> and_then(F &&f) const && {
     using result = detail::invoke_result_t<F, const T &&>;
@@ -815,46 +780,24 @@ public:
 
 #if defined(TL_OPTIONAL_CXX14) && !defined(TL_OPTIONAL_GCC49) &&               \
     !defined(TL_OPTIONAL_GCC54) && !defined(TL_OPTIONAL_GCC55)
-  /// \brief Carries out some operation on the stored object if there is one.
-  /// \returns Let `U` be the result of `std::invoke(std::forward<F>(f),
-  /// value())`. Returns a `std::optional<U>`. The return value is empty if
-  /// `*this` is empty, otherwise an `optional<U>` is constructed from the
-  /// return value of `std::invoke(std::forward<F>(f), value())` and is
-  /// returned.
-  ///
-  /// \group map
-  /// \synopsis template <class F> constexpr auto map(F &&f) &;
+  /// Carries out some operation on the stored object if there is one.
   template <class F> TL_OPTIONAL_11_CONSTEXPR auto map(F &&f) & {
     return optional_map_impl(*this, std::forward<F>(f));
   }
 
-  /// \group map
-  /// \synopsis template <class F> constexpr auto map(F &&f) &&;
   template <class F> TL_OPTIONAL_11_CONSTEXPR auto map(F &&f) && {
     return optional_map_impl(std::move(*this), std::forward<F>(f));
   }
 
-  /// \group map
-  /// \synopsis template <class F> constexpr auto map(F &&f) const&;
   template <class F> constexpr auto map(F &&f) const & {
     return optional_map_impl(*this, std::forward<F>(f));
   }
 
-  /// \group map
-  /// \synopsis template <class F> constexpr auto map(F &&f) const&&;
   template <class F> constexpr auto map(F &&f) const && {
     return optional_map_impl(std::move(*this), std::forward<F>(f));
   }
 #else
-  /// \brief Carries out some operation on the stored object if there is one.
-  /// \returns Let `U` be the result of `std::invoke(std::forward<F>(f),
-  /// value())`. Returns a `std::optional<U>`. The return value is empty if
-  /// `*this` is empty, otherwise an `optional<U>` is constructed from the
-  /// return value of `std::invoke(std::forward<F>(f), value())` and is
-  /// returned.
-  ///
-  /// \group map
-  /// \synopsis template <class F> auto map(F &&f) &;
+  /// Carries out some operation on the stored object if there is one.
   template <class F>
   TL_OPTIONAL_11_CONSTEXPR decltype(optional_map_impl(std::declval<optional &>(),
                                              std::declval<F &&>()))
@@ -862,8 +805,6 @@ public:
     return optional_map_impl(*this, std::forward<F>(f));
   }
 
-  /// \group map
-  /// \synopsis template <class F> auto map(F &&f) &&;
   template <class F>
   TL_OPTIONAL_11_CONSTEXPR decltype(optional_map_impl(std::declval<optional &&>(),
                                              std::declval<F &&>()))
@@ -871,8 +812,6 @@ public:
     return optional_map_impl(std::move(*this), std::forward<F>(f));
   }
 
-  /// \group map
-  /// \synopsis template <class F> auto map(F &&f) const&;
   template <class F>
   constexpr decltype(optional_map_impl(std::declval<const optional &>(),
                               std::declval<F &&>()))
@@ -881,8 +820,6 @@ public:
   }
 
 #ifndef TL_OPTIONAL_NO_CONSTRR
-  /// \group map
-  /// \synopsis template <class F> auto map(F &&f) const&&;
   template <class F>
   constexpr decltype(optional_map_impl(std::declval<const optional &&>(),
                               std::declval<F &&>()))
@@ -892,15 +829,58 @@ public:
 #endif
 #endif
 
-  /// \brief Calls `f` if the optional is empty
-  /// \requires `std::invoke_result_t<F>` must be void or convertible to
-  /// `optional<T>`.
-  /// \effects If `*this` has a value, returns `*this`.
-  /// Otherwise, if `f` returns `void`, calls `std::forward<F>(f)` and returns
-  /// `std::nullopt`. Otherwise, returns `std::forward<F>(f)()`.
-  ///
-  /// \group or_else
-  /// \synopsis template <class F> optional<T> or_else (F &&f) &;
+#if defined(TL_OPTIONAL_CXX14) && !defined(TL_OPTIONAL_GCC49) &&               \
+    !defined(TL_OPTIONAL_GCC54) && !defined(TL_OPTIONAL_GCC55)
+  /// Carries out some operation on the stored object if there is one.
+  template <class F> TL_OPTIONAL_11_CONSTEXPR auto transform(F&& f) & {
+    return optional_map_impl(*this, std::forward<F>(f));
+  }
+
+  template <class F> TL_OPTIONAL_11_CONSTEXPR auto transform(F&& f) && {
+    return optional_map_impl(std::move(*this), std::forward<F>(f));
+  }
+
+  template <class F> constexpr auto transform(F&& f) const & {
+    return optional_map_impl(*this, std::forward<F>(f));
+  }
+
+  template <class F> constexpr auto transform(F&& f) const && {
+    return optional_map_impl(std::move(*this), std::forward<F>(f));
+  }
+#else
+  /// Carries out some operation on the stored object if there is one.
+  template <class F>
+  TL_OPTIONAL_11_CONSTEXPR decltype(optional_map_impl(std::declval<optional&>(),
+    std::declval<F&&>()))
+    transform(F&& f) & {
+    return optional_map_impl(*this, std::forward<F>(f));
+  }
+
+  template <class F>
+  TL_OPTIONAL_11_CONSTEXPR decltype(optional_map_impl(std::declval<optional&&>(),
+    std::declval<F&&>()))
+    transform(F&& f) && {
+    return optional_map_impl(std::move(*this), std::forward<F>(f));
+  }
+
+  template <class F>
+  constexpr decltype(optional_map_impl(std::declval<const optional&>(),
+    std::declval<F&&>()))
+    transform(F&& f) const & {
+    return optional_map_impl(*this, std::forward<F>(f));
+  }
+
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  template <class F>
+  constexpr decltype(optional_map_impl(std::declval<const optional&&>(),
+    std::declval<F&&>()))
+    transform(F&& f) const && {
+    return optional_map_impl(std::move(*this), std::forward<F>(f));
+  }
+#endif
+#endif
+
+  /// Calls `f` if the optional is empty
   template <class F, detail::enable_if_ret_void<F> * = nullptr>
   optional<T> TL_OPTIONAL_11_CONSTEXPR or_else(F &&f) & {
     if (has_value())
@@ -910,14 +890,11 @@ public:
     return nullopt;
   }
 
-  /// \exclude
   template <class F, detail::disable_if_ret_void<F> * = nullptr>
   optional<T> TL_OPTIONAL_11_CONSTEXPR or_else(F &&f) & {
     return has_value() ? *this : std::forward<F>(f)();
   }
 
-  /// \group or_else
-  /// \synopsis template <class F> optional<T> or_else (F &&f) &&;
   template <class F, detail::enable_if_ret_void<F> * = nullptr>
   optional<T> or_else(F &&f) && {
     if (has_value())
@@ -927,14 +904,11 @@ public:
     return nullopt;
   }
 
-  /// \exclude
   template <class F, detail::disable_if_ret_void<F> * = nullptr>
   optional<T> TL_OPTIONAL_11_CONSTEXPR or_else(F &&f) && {
     return has_value() ? std::move(*this) : std::forward<F>(f)();
   }
 
-  /// \group or_else
-  /// \synopsis template <class F> optional<T> or_else (F &&f) const &;
   template <class F, detail::enable_if_ret_void<F> * = nullptr>
   optional<T> or_else(F &&f) const & {
     if (has_value())
@@ -944,14 +918,12 @@ public:
     return nullopt;
   }
 
-  /// \exclude
   template <class F, detail::disable_if_ret_void<F> * = nullptr>
   optional<T> TL_OPTIONAL_11_CONSTEXPR or_else(F &&f) const & {
     return has_value() ? *this : std::forward<F>(f)();
   }
 
 #ifndef TL_OPTIONAL_NO_CONSTRR
-  /// \exclude
   template <class F, detail::enable_if_ret_void<F> * = nullptr>
   optional<T> or_else(F &&f) const && {
     if (has_value())
@@ -961,72 +933,49 @@ public:
     return nullopt;
   }
 
-  /// \exclude
   template <class F, detail::disable_if_ret_void<F> * = nullptr>
   optional<T> or_else(F &&f) const && {
     return has_value() ? std::move(*this) : std::forward<F>(f)();
   }
 #endif
 
-  /// \brief Maps the stored value with `f` if there is one, otherwise returns
-  /// `u`.
-  ///
-  /// \details If there is a value stored, then `f` is called with `**this`
-  /// and the value is returned. Otherwise `u` is returned.
-  ///
-  /// \group map_or
+  /// Maps the stored value with `f` if there is one, otherwise returns `u`.
   template <class F, class U> U map_or(F &&f, U &&u) & {
     return has_value() ? detail::invoke(std::forward<F>(f), **this)
                        : std::forward<U>(u);
   }
 
-  /// \group map_or
   template <class F, class U> U map_or(F &&f, U &&u) && {
     return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
                        : std::forward<U>(u);
   }
 
-  /// \group map_or
   template <class F, class U> U map_or(F &&f, U &&u) const & {
     return has_value() ? detail::invoke(std::forward<F>(f), **this)
                        : std::forward<U>(u);
   }
 
 #ifndef TL_OPTIONAL_NO_CONSTRR
-  /// \group map_or
   template <class F, class U> U map_or(F &&f, U &&u) const && {
     return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
                        : std::forward<U>(u);
   }
 #endif
 
-  /// \brief Maps the stored value with `f` if there is one, otherwise calls
+  /// Maps the stored value with `f` if there is one, otherwise calls
   /// `u` and returns the result.
-  ///
-  /// \details If there is a value stored, then `f` is
-  /// called with `**this` and the value is returned. Otherwise
-  /// `std::forward<U>(u)()` is returned.
-  ///
-  /// \group map_or_else
-  /// \synopsis template <class F, class U>\nauto map_or_else(F &&f, U &&u) &;
   template <class F, class U>
   detail::invoke_result_t<U> map_or_else(F &&f, U &&u) & {
     return has_value() ? detail::invoke(std::forward<F>(f), **this)
                        : std::forward<U>(u)();
   }
 
-  /// \group map_or_else
-  /// \synopsis template <class F, class U>\nauto map_or_else(F &&f, U &&u)
-  /// &&;
   template <class F, class U>
   detail::invoke_result_t<U> map_or_else(F &&f, U &&u) && {
     return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
                        : std::forward<U>(u)();
   }
 
-  /// \group map_or_else
-  /// \synopsis template <class F, class U>\nauto map_or_else(F &&f, U &&u)
-  /// const &;
   template <class F, class U>
   detail::invoke_result_t<U> map_or_else(F &&f, U &&u) const & {
     return has_value() ? detail::invoke(std::forward<F>(f), **this)
@@ -1034,9 +983,6 @@ public:
   }
 
 #ifndef TL_OPTIONAL_NO_CONSTRR
-  /// \group map_or_else
-  /// \synopsis template <class F, class U>\nauto map_or_else(F &&f, U &&u)
-  /// const &&;
   template <class F, class U>
   detail::invoke_result_t<U> map_or_else(F &&f, U &&u) const && {
     return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
@@ -1044,96 +990,62 @@ public:
   }
 #endif
 
-  /// \returns `u` if `*this` has a value, otherwise an empty optional.
+  /// Returns `u` if `*this` has a value, otherwise an empty optional.
   template <class U>
   constexpr optional<typename std::decay<U>::type> conjunction(U &&u) const {
     using result = optional<detail::decay_t<U>>;
     return has_value() ? result{u} : result{nullopt};
   }
 
-  /// \returns `rhs` if `*this` is empty, otherwise the current value.
-  /// \group disjunction
+  /// Returns `rhs` if `*this` is empty, otherwise the current value.
   TL_OPTIONAL_11_CONSTEXPR optional disjunction(const optional &rhs) & {
     return has_value() ? *this : rhs;
   }
 
-  /// \group disjunction
   constexpr optional disjunction(const optional &rhs) const & {
     return has_value() ? *this : rhs;
   }
 
-  /// \group disjunction
   TL_OPTIONAL_11_CONSTEXPR optional disjunction(const optional &rhs) && {
     return has_value() ? std::move(*this) : rhs;
   }
 
 #ifndef TL_OPTIONAL_NO_CONSTRR
-  /// \group disjunction
   constexpr optional disjunction(const optional &rhs) const && {
     return has_value() ? std::move(*this) : rhs;
   }
 #endif
 
-  /// \group disjunction
   TL_OPTIONAL_11_CONSTEXPR optional disjunction(optional &&rhs) & {
     return has_value() ? *this : std::move(rhs);
   }
 
-  /// \group disjunction
   constexpr optional disjunction(optional &&rhs) const & {
     return has_value() ? *this : std::move(rhs);
   }
 
-  /// \group disjunction
   TL_OPTIONAL_11_CONSTEXPR optional disjunction(optional &&rhs) && {
     return has_value() ? std::move(*this) : std::move(rhs);
   }
 
 #ifndef TL_OPTIONAL_NO_CONSTRR
-  /// \group disjunction
   constexpr optional disjunction(optional &&rhs) const && {
     return has_value() ? std::move(*this) : std::move(rhs);
   }
 #endif
 
   /// Takes the value out of the optional, leaving it empty
-  /// \group take
-  optional take() & {
-    optional ret = *this;
-    reset();
-    return ret;
-  }
-
-  /// \group take
-  optional take() const & {
-    optional ret = *this;
-    reset();
-    return ret;
-  }
-
-  /// \group take
-  optional take() && {
+  optional take() {
     optional ret = std::move(*this);
     reset();
     return ret;
   }
-
-#ifndef TL_OPTIONAL_NO_CONSTRR
-  /// \group take
-  optional take() const && {
-    optional ret = std::move(*this);
-    reset();
-    return ret;
-  }
-#endif
 
   using value_type = T;
 
   /// Constructs an optional that does not contain a value.
-  /// \group ctor_empty
   constexpr optional() noexcept = default;
 
-  /// \group ctor_empty
   constexpr optional(nullopt_t) noexcept {}
 
   /// Copy constructor
@@ -1149,16 +1061,12 @@ public:
   TL_OPTIONAL_11_CONSTEXPR optional(optional &&rhs) = default;
 
   /// Constructs the stored value in-place using the given arguments.
-  /// \group in_place
-  /// \synopsis template <class... Args> constexpr explicit optional(in_place_t, Args&&... args);
-  template <class... Args>
+ template <class... Args>
   constexpr explicit optional(
       detail::enable_if_t<std::is_constructible<T, Args...>::value, in_place_t>,
       Args &&... args)
       : base(in_place, std::forward<Args>(args)...) {}
 
-  /// \group in_place
-  /// \synopsis template <class U, class... Args>\nconstexpr explicit optional(in_place_t, std::initializer_list<U>&, Args&&... args);
   template <class U, class... Args>
   TL_OPTIONAL_11_CONSTEXPR explicit optional(
       detail::enable_if_t<std::is_constructible<T, std::initializer_list<U> &,
@@ -1169,14 +1077,12 @@ public:
   }
 
   /// Constructs the stored value with `u`.
-  /// \synopsis template <class U=T> constexpr optional(U &&u);
   template <
       class U = T,
       detail::enable_if_t<std::is_convertible<U &&, T>::value> * = nullptr,
       detail::enable_forward_value<T, U> * = nullptr>
   constexpr optional(U &&u) : base(in_place, std::forward<U>(u)) {}
 
-  /// \exclude
   template <
       class U = T,
       detail::enable_if_t<!std::is_convertible<U &&, T>::value> * = nullptr,
@@ -1184,7 +1090,6 @@ public:
   constexpr explicit optional(U &&u) : base(in_place, std::forward<U>(u)) {}
 
   /// Converting copy constructor.
-  /// \synopsis template <class U> optional(const optional<U> &rhs);
   template <
       class U, detail::enable_from_other<T, U, const U &> * = nullptr,
       detail::enable_if_t<std::is_convertible<const U &, T>::value> * = nullptr>
@@ -1194,7 +1099,6 @@ public:
     }
   }
 
-  /// \exclude
   template <class U, detail::enable_from_other<T, U, const U &> * = nullptr,
             detail::enable_if_t<!std::is_convertible<const U &, T>::value> * =
                 nullptr>
@@ -1205,7 +1109,6 @@ public:
   }
 
   /// Converting move constructor.
-  /// \synopsis template <class U> optional(optional<U> &&rhs);
   template <
       class U, detail::enable_from_other<T, U, U &&> * = nullptr,
       detail::enable_if_t<std::is_convertible<U &&, T>::value> * = nullptr>
@@ -1215,7 +1118,6 @@ public:
     }
   }
 
-  /// \exclude
   template <
       class U, detail::enable_from_other<T, U, U &&> * = nullptr,
       detail::enable_if_t<!std::is_convertible<U &&, T>::value> * = nullptr>
@@ -1254,7 +1156,6 @@ public:
 
   /// Assigns the stored value from `u`, destroying the old value if there was
   /// one.
-  /// \synopsis optional &operator=(U &&u);
   template <class U = T, detail::enable_assign_forward<T, U> * = nullptr>
   optional &operator=(U &&u) {
     if (has_value()) {
@@ -1270,7 +1171,6 @@ public:
   ///
   /// Copies the value from `rhs` if there is one. Otherwise resets the stored
   /// value in `*this`.
-  /// \synopsis optional &operator=(const optional<U> & rhs);
   template <class U,
             detail::enable_assign_from_other<T, U, const U &> * = nullptr>
   optional &operator=(const optional<U> &rhs) {
@@ -1282,7 +1182,7 @@ public:
       }
     }
 
-    if (rhs.has_value()) {
+    else if (rhs.has_value()) {
       this->construct(*rhs);
     }
 
@@ -1294,7 +1194,6 @@ public:
   ///
   /// Moves the value from `rhs` if there is one. Otherwise resets the stored
   /// value in `*this`.
-  /// \synopsis optional &operator=(optional<U> && rhs);
   template <class U, detail::enable_assign_from_other<T, U, U> * = nullptr>
   optional &operator=(optional<U> &&rhs) {
     if (has_value()) {
@@ -1305,7 +1204,7 @@ public:
       }
     }
 
-    if (rhs.has_value()) {
+    else if (rhs.has_value()) {
       this->construct(std::move(*rhs));
     }
 
@@ -1314,7 +1213,6 @@ public:
 
   /// Constructs the value in-place, destroying the current one if there is
   /// one.
-  /// \group emplace
   template <class... Args> T &emplace(Args &&... args) {
     static_assert(std::is_constructible<T, Args &&...>::value,
                   "T must be constructible with Args");
@@ -1324,8 +1222,6 @@ public:
     return value();
   }
 
-  /// \group emplace
-  /// \synopsis template <class U, class... Args>\nT& emplace(std::initializer_list<U> il, Args &&... args);
   template <class U, class... Args>
   detail::enable_if_t<
       std::is_constructible<T, std::initializer_list<U> &, Args &&...>::value,
@@ -1333,7 +1229,7 @@ public:
   emplace(std::initializer_list<U> il, Args &&... args) {
     *this = nullopt;
     this->construct(il, std::forward<Args>(args)...);
-    return value();
+    return value();    
   }
 
   /// Swaps this optional with the other.
@@ -1345,9 +1241,9 @@ public:
   void
   swap(optional &rhs) noexcept(std::is_nothrow_move_constructible<T>::value
                                    &&detail::is_nothrow_swappable<T>::value) {
+    using std::swap;
     if (has_value()) {
       if (rhs.has_value()) {
-        using std::swap;
         swap(**this, *rhs);
       } else {
         new (std::addressof(rhs.m_value)) T(std::move(this->m_value));
@@ -1357,68 +1253,49 @@ public:
       new (std::addressof(this->m_value)) T(std::move(rhs.m_value));
       rhs.m_value.T::~T();
     }
+    swap(this->m_has_value, rhs.m_has_value);
   }
 
-  /// \returns a pointer to the stored value
-  /// \requires a value is stored
-  /// \group pointer
-  /// \synopsis constexpr const T *operator->() const;
+  /// Returns a pointer to the stored value
   constexpr const T *operator->() const {
     return std::addressof(this->m_value);
   }
 
-  /// \group pointer
-  /// \synopsis constexpr T *operator->();
   TL_OPTIONAL_11_CONSTEXPR T *operator->() {
     return std::addressof(this->m_value);
   }
 
-  /// \returns the stored value
-  /// \requires a value is stored
-  /// \group deref
-  /// \synopsis constexpr T &operator*();
+  /// Returns the stored value
   TL_OPTIONAL_11_CONSTEXPR T &operator*() & { return this->m_value; }
 
-  /// \group deref
-  /// \synopsis constexpr const T &operator*() const;
   constexpr const T &operator*() const & { return this->m_value; }
 
-  /// \exclude
   TL_OPTIONAL_11_CONSTEXPR T &&operator*() && {
     return std::move(this->m_value);
   }
 
 #ifndef TL_OPTIONAL_NO_CONSTRR
-  /// \exclude
   constexpr const T &&operator*() const && { return std::move(this->m_value); }
 #endif
 
-  /// \returns whether or not the optional has a value
-  /// \group has_value
+  /// Returns whether or not the optional has a value
   constexpr bool has_value() const noexcept { return this->m_has_value; }
 
-  /// \group has_value
   constexpr explicit operator bool() const noexcept {
     return this->m_has_value;
   }
 
-  /// \returns the contained value if there is one, otherwise throws
-  /// [bad_optional_access]
-  /// \group value
-  /// \synopsis constexpr T &value();
+  /// Returns the contained value if there is one, otherwise throws bad_optional_access
   TL_OPTIONAL_11_CONSTEXPR T &value() & {
     if (has_value())
       return this->m_value;
     throw bad_optional_access();
   }
-  /// \group value
-  /// \synopsis constexpr const T &value() const;
   TL_OPTIONAL_11_CONSTEXPR const T &value() const & {
     if (has_value())
       return this->m_value;
     throw bad_optional_access();
   }
-  /// \exclude
   TL_OPTIONAL_11_CONSTEXPR T &&value() && {
     if (has_value())
       return std::move(this->m_value);
@@ -1426,7 +1303,6 @@ public:
   }
 
 #ifndef TL_OPTIONAL_NO_CONSTRR
-  /// \exclude
   TL_OPTIONAL_11_CONSTEXPR const T &&value() const && {
     if (has_value())
       return std::move(this->m_value);
@@ -1434,8 +1310,7 @@ public:
   }
 #endif
 
-  /// \returns the stored value if there is one, otherwise returns `u`
-  /// \group value_or
+  /// Returns the stored value if there is one, otherwise returns `u`
   template <class U> constexpr T value_or(U &&u) const & {
     static_assert(std::is_copy_constructible<T>::value &&
                       std::is_convertible<U &&, T>::value,
@@ -1443,12 +1318,11 @@ public:
     return has_value() ? **this : static_cast<T>(std::forward<U>(u));
   }
 
-  /// \group value_or
   template <class U> TL_OPTIONAL_11_CONSTEXPR T value_or(U &&u) && {
     static_assert(std::is_move_constructible<T>::value &&
                       std::is_convertible<U &&, T>::value,
                   "T must be move constructible and convertible from U");
-    return has_value() ? **this : static_cast<T>(std::forward<U>(u));
+    return has_value() ? std::move(**this) : static_cast<T>(std::forward<U>(u));
   }
 
   /// Destroys the stored value if one exists, making the optional empty
@@ -1460,179 +1334,140 @@ public:
   }
 }; // namespace tl
 
-/// \group relop
-/// \brief Compares two optional objects
-/// \details If both optionals contain a value, they are compared with `T`s
-/// relational operators. Otherwise `lhs` and `rhs` are equal only if they are
-/// both empty, and `lhs` is less than `rhs` only if `rhs` is empty and `lhs`
-/// is not.
+/// Compares two optional objects
 template <class T, class U>
 inline constexpr bool operator==(const optional<T> &lhs,
                                  const optional<U> &rhs) {
   return lhs.has_value() == rhs.has_value() &&
          (!lhs.has_value() || *lhs == *rhs);
 }
-/// \group relop
 template <class T, class U>
 inline constexpr bool operator!=(const optional<T> &lhs,
                                  const optional<U> &rhs) {
   return lhs.has_value() != rhs.has_value() ||
          (lhs.has_value() && *lhs != *rhs);
 }
-/// \group relop
 template <class T, class U>
 inline constexpr bool operator<(const optional<T> &lhs,
                                 const optional<U> &rhs) {
   return rhs.has_value() && (!lhs.has_value() || *lhs < *rhs);
 }
-/// \group relop
 template <class T, class U>
 inline constexpr bool operator>(const optional<T> &lhs,
                                 const optional<U> &rhs) {
   return lhs.has_value() && (!rhs.has_value() || *lhs > *rhs);
 }
-/// \group relop
 template <class T, class U>
 inline constexpr bool operator<=(const optional<T> &lhs,
                                  const optional<U> &rhs) {
   return !lhs.has_value() || (rhs.has_value() && *lhs <= *rhs);
 }
-/// \group relop
 template <class T, class U>
 inline constexpr bool operator>=(const optional<T> &lhs,
                                  const optional<U> &rhs) {
   return !rhs.has_value() || (lhs.has_value() && *lhs >= *rhs);
 }
 
-/// \group relop_nullopt
-/// \brief Compares an optional to a `nullopt`
-/// \details Equivalent to comparing the optional to an empty optional
+/// Compares an optional to a `nullopt`
 template <class T>
 inline constexpr bool operator==(const optional<T> &lhs, nullopt_t) noexcept {
   return !lhs.has_value();
 }
-/// \group relop_nullopt
 template <class T>
 inline constexpr bool operator==(nullopt_t, const optional<T> &rhs) noexcept {
   return !rhs.has_value();
 }
-/// \group relop_nullopt
 template <class T>
 inline constexpr bool operator!=(const optional<T> &lhs, nullopt_t) noexcept {
   return lhs.has_value();
 }
-/// \group relop_nullopt
 template <class T>
 inline constexpr bool operator!=(nullopt_t, const optional<T> &rhs) noexcept {
   return rhs.has_value();
 }
-/// \group relop_nullopt
 template <class T>
 inline constexpr bool operator<(const optional<T> &, nullopt_t) noexcept {
   return false;
 }
-/// \group relop_nullopt
 template <class T>
 inline constexpr bool operator<(nullopt_t, const optional<T> &rhs) noexcept {
   return rhs.has_value();
 }
-/// \group relop_nullopt
 template <class T>
 inline constexpr bool operator<=(const optional<T> &lhs, nullopt_t) noexcept {
   return !lhs.has_value();
 }
-/// \group relop_nullopt
 template <class T>
 inline constexpr bool operator<=(nullopt_t, const optional<T> &) noexcept {
   return true;
 }
-/// \group relop_nullopt
 template <class T>
 inline constexpr bool operator>(const optional<T> &lhs, nullopt_t) noexcept {
   return lhs.has_value();
 }
-/// \group relop_nullopt
 template <class T>
 inline constexpr bool operator>(nullopt_t, const optional<T> &) noexcept {
   return false;
 }
-/// \group relop_nullopt
 template <class T>
 inline constexpr bool operator>=(const optional<T> &, nullopt_t) noexcept {
   return true;
 }
-/// \group relop_nullopt
 template <class T>
 inline constexpr bool operator>=(nullopt_t, const optional<T> &rhs) noexcept {
   return !rhs.has_value();
 }
 
-/// \group relop_t
-/// \brief Compares the optional with a value.
-/// \details If the optional has a value, it is compared with the other value
-/// using `T`s relational operators. Otherwise, the optional is considered
-/// less than the value.
+/// Compares the optional with a value.
 template <class T, class U>
 inline constexpr bool operator==(const optional<T> &lhs, const U &rhs) {
   return lhs.has_value() ? *lhs == rhs : false;
 }
-/// \group relop_t
 template <class T, class U>
 inline constexpr bool operator==(const U &lhs, const optional<T> &rhs) {
   return rhs.has_value() ? lhs == *rhs : false;
 }
-/// \group relop_t
 template <class T, class U>
 inline constexpr bool operator!=(const optional<T> &lhs, const U &rhs) {
   return lhs.has_value() ? *lhs != rhs : true;
 }
-/// \group relop_t
 template <class T, class U>
 inline constexpr bool operator!=(const U &lhs, const optional<T> &rhs) {
   return rhs.has_value() ? lhs != *rhs : true;
 }
-/// \group relop_t
 template <class T, class U>
 inline constexpr bool operator<(const optional<T> &lhs, const U &rhs) {
   return lhs.has_value() ? *lhs < rhs : true;
 }
-/// \group relop_t
 template <class T, class U>
 inline constexpr bool operator<(const U &lhs, const optional<T> &rhs) {
   return rhs.has_value() ? lhs < *rhs : false;
 }
-/// \group relop_t
 template <class T, class U>
 inline constexpr bool operator<=(const optional<T> &lhs, const U &rhs) {
   return lhs.has_value() ? *lhs <= rhs : true;
 }
-/// \group relop_t
 template <class T, class U>
 inline constexpr bool operator<=(const U &lhs, const optional<T> &rhs) {
   return rhs.has_value() ? lhs <= *rhs : false;
 }
-/// \group relop_t
 template <class T, class U>
 inline constexpr bool operator>(const optional<T> &lhs, const U &rhs) {
   return lhs.has_value() ? *lhs > rhs : false;
 }
-/// \group relop_t
 template <class T, class U>
 inline constexpr bool operator>(const U &lhs, const optional<T> &rhs) {
   return rhs.has_value() ? lhs > *rhs : true;
 }
-/// \group relop_t
 template <class T, class U>
 inline constexpr bool operator>=(const optional<T> &lhs, const U &rhs) {
   return lhs.has_value() ? *lhs >= rhs : false;
 }
-/// \group relop_t
 template <class T, class U>
 inline constexpr bool operator>=(const U &lhs, const optional<T> &rhs) {
   return rhs.has_value() ? lhs >= *rhs : true;
 }
 
-/// \synopsis template <class T>\nvoid swap(optional<T> &lhs, optional<T> &rhs);
 template <class T,
           detail::enable_if_t<std::is_move_constructible<T>::value> * = nullptr,
           detail::enable_if_t<detail::is_swappable<T>::value> * = nullptr>
@@ -1722,26 +1557,6 @@ auto optional_map_impl(Opt &&opt, F &&f) -> optional<monostate> {
 
 /// Specialization for when `T` is a reference. `optional<T&>` acts similarly
 /// to a `T*`, but provides more operations and shows intent more clearly.
-///
-/// *Examples*:
-///
-/// ```
-/// int i = 42;
-/// tl::optional<int&> o = i;
-/// *o == 42; //true
-/// i = 12;
-/// *o = 12; //true
-/// &*o == &i; //true
-/// ```
-///
-/// Assignment has rebind semantics rather than assign-through semantics:
-///
-/// ```
-/// int j = 8;
-/// o = j;
-///
-/// &*o == &j; //true
-/// ```
 template <class T> class optional<T &> {
 public:
 // The different versions for C++14 and 11 are needed because deduced return
@@ -1750,16 +1565,9 @@ public:
 // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0826r0.html
 #if defined(TL_OPTIONAL_CXX14) && !defined(TL_OPTIONAL_GCC49) &&               \
     !defined(TL_OPTIONAL_GCC54) && !defined(TL_OPTIONAL_GCC55)
-  /// \group and_then
+
   /// Carries out some operation which returns an optional on the stored
-  /// object if there is one. \requires `std::invoke(std::forward<F>(f),
-  /// value())` returns a `std::optional<U>` for some `U`. \returns Let `U` be
-  /// the result of `std::invoke(std::forward<F>(f), value())`. Returns a
-  /// `std::optional<U>`. The return value is empty if `*this` is empty,
-  /// otherwise the return value of `std::invoke(std::forward<F>(f), value())`
-  /// is returned.
-  /// \group and_then
-  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) &;
+  /// object if there is one.
   template <class F> TL_OPTIONAL_11_CONSTEXPR auto and_then(F &&f) & {
     using result = detail::invoke_result_t<F, T &>;
     static_assert(detail::is_optional<result>::value,
@@ -1769,8 +1577,6 @@ public:
                        : result(nullopt);
   }
 
-  /// \group and_then
-  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) &&;
   template <class F> TL_OPTIONAL_11_CONSTEXPR auto and_then(F &&f) && {
     using result = detail::invoke_result_t<F, T &>;
     static_assert(detail::is_optional<result>::value,
@@ -1780,8 +1586,6 @@ public:
                        : result(nullopt);
   }
 
-  /// \group and_then
-  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) const &;
   template <class F> constexpr auto and_then(F &&f) const & {
     using result = detail::invoke_result_t<F, const T &>;
     static_assert(detail::is_optional<result>::value,
@@ -1792,8 +1596,6 @@ public:
   }
 
 #ifndef TL_OPTIONAL_NO_CONSTRR
-  /// \group and_then
-  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) const &&;
   template <class F> constexpr auto and_then(F &&f) const && {
     using result = detail::invoke_result_t<F, const T &>;
     static_assert(detail::is_optional<result>::value,
@@ -1804,16 +1606,8 @@ public:
   }
 #endif
 #else
-  /// \group and_then
   /// Carries out some operation which returns an optional on the stored
-  /// object if there is one. \requires `std::invoke(std::forward<F>(f),
-  /// value())` returns a `std::optional<U>` for some `U`. \returns Let `U` be
-  /// the result of `std::invoke(std::forward<F>(f), value())`. Returns a
-  /// `std::optional<U>`. The return value is empty if `*this` is empty,
-  /// otherwise the return value of `std::invoke(std::forward<F>(f), value())`
-  /// is returned.
-  /// \group and_then
-  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) &;
+  /// object if there is one.
   template <class F>
   TL_OPTIONAL_11_CONSTEXPR detail::invoke_result_t<F, T &> and_then(F &&f) & {
     using result = detail::invoke_result_t<F, T &>;
@@ -1824,8 +1618,6 @@ public:
                        : result(nullopt);
   }
 
-  /// \group and_then
-  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) &&;
   template <class F>
   TL_OPTIONAL_11_CONSTEXPR detail::invoke_result_t<F, T &> and_then(F &&f) && {
     using result = detail::invoke_result_t<F, T &>;
@@ -1836,8 +1628,6 @@ public:
                        : result(nullopt);
   }
 
-  /// \group and_then
-  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) const &;
   template <class F>
   constexpr detail::invoke_result_t<F, const T &> and_then(F &&f) const & {
     using result = detail::invoke_result_t<F, const T &>;
@@ -1849,15 +1639,13 @@ public:
   }
 
 #ifndef TL_OPTIONAL_NO_CONSTRR
-  /// \group and_then
-  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) const &&;
   template <class F>
   constexpr detail::invoke_result_t<F, const T &> and_then(F &&f) const && {
     using result = detail::invoke_result_t<F, const T &>;
     static_assert(detail::is_optional<result>::value,
                   "F must return an optional");
 
-    return has_value() ? detail::invoke(std::forward<F>(f), **this)
+    return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
                        : result(nullopt);
   }
 #endif
@@ -1865,46 +1653,24 @@ public:
 
 #if defined(TL_OPTIONAL_CXX14) && !defined(TL_OPTIONAL_GCC49) &&               \
     !defined(TL_OPTIONAL_GCC54) && !defined(TL_OPTIONAL_GCC55)
-  /// \brief Carries out some operation on the stored object if there is one.
-  /// \returns Let `U` be the result of `std::invoke(std::forward<F>(f),
-  /// value())`. Returns a `std::optional<U>`. The return value is empty if
-  /// `*this` is empty, otherwise an `optional<U>` is constructed from the
-  /// return value of `std::invoke(std::forward<F>(f), value())` and is
-  /// returned.
-  ///
-  /// \group map
-  /// \synopsis template <class F> constexpr auto map(F &&f) &;
+  /// Carries out some operation on the stored object if there is one.
   template <class F> TL_OPTIONAL_11_CONSTEXPR auto map(F &&f) & {
     return detail::optional_map_impl(*this, std::forward<F>(f));
   }
 
-  /// \group map
-  /// \synopsis template <class F> constexpr auto map(F &&f) &&;
   template <class F> TL_OPTIONAL_11_CONSTEXPR auto map(F &&f) && {
     return detail::optional_map_impl(std::move(*this), std::forward<F>(f));
   }
 
-  /// \group map
-  /// \synopsis template <class F> constexpr auto map(F &&f) const&;
   template <class F> constexpr auto map(F &&f) const & {
     return detail::optional_map_impl(*this, std::forward<F>(f));
   }
 
-  /// \group map
-  /// \synopsis template <class F> constexpr auto map(F &&f) const&&;
   template <class F> constexpr auto map(F &&f) const && {
     return detail::optional_map_impl(std::move(*this), std::forward<F>(f));
   }
 #else
-  /// \brief Carries out some operation on the stored object if there is one.
-  /// \returns Let `U` be the result of `std::invoke(std::forward<F>(f),
-  /// value())`. Returns a `std::optional<U>`. The return value is empty if
-  /// `*this` is empty, otherwise an `optional<U>` is constructed from the
-  /// return value of `std::invoke(std::forward<F>(f), value())` and is
-  /// returned.
-  ///
-  /// \group map
-  /// \synopsis template <class F> auto map(F &&f) &;
+  /// Carries out some operation on the stored object if there is one.
   template <class F>
   TL_OPTIONAL_11_CONSTEXPR decltype(detail::optional_map_impl(std::declval<optional &>(),
                                                      std::declval<F &&>()))
@@ -1912,8 +1678,6 @@ public:
     return detail::optional_map_impl(*this, std::forward<F>(f));
   }
 
-  /// \group map
-  /// \synopsis template <class F> auto map(F &&f) &&;
   template <class F>
   TL_OPTIONAL_11_CONSTEXPR decltype(detail::optional_map_impl(std::declval<optional &&>(),
                                                      std::declval<F &&>()))
@@ -1921,8 +1685,6 @@ public:
     return detail::optional_map_impl(std::move(*this), std::forward<F>(f));
   }
 
-  /// \group map
-  /// \synopsis template <class F> auto map(F &&f) const&;
   template <class F>
   constexpr decltype(detail::optional_map_impl(std::declval<const optional &>(),
                                       std::declval<F &&>()))
@@ -1931,8 +1693,6 @@ public:
   }
 
 #ifndef TL_OPTIONAL_NO_CONSTRR
-  /// \group map
-  /// \synopsis template <class F> auto map(F &&f) const&&;
   template <class F>
   constexpr decltype(detail::optional_map_impl(std::declval<const optional &&>(),
                                       std::declval<F &&>()))
@@ -1942,14 +1702,60 @@ public:
 #endif
 #endif
 
-  /// \brief Calls `f` if the optional is empty
-  /// \requires `std::invoke_result_t<F>` must be void or convertible to
-  /// `optional<T>`. \effects If `*this` has a value, returns `*this`.
-  /// Otherwise, if `f` returns `void`, calls `std::forward<F>(f)` and returns
-  /// `std::nullopt`. Otherwise, returns `std::forward<F>(f)()`.
-  ///
-  /// \group or_else
-  /// \synopsis template <class F> optional<T> or_else (F &&f) &;
+#if defined(TL_OPTIONAL_CXX14) && !defined(TL_OPTIONAL_GCC49) &&               \
+    !defined(TL_OPTIONAL_GCC54) && !defined(TL_OPTIONAL_GCC55)
+  /// Carries out some operation on the stored object if there is one.
+  template <class F> TL_OPTIONAL_11_CONSTEXPR auto transform(F&& f) & {
+    return detail::optional_map_impl(*this, std::forward<F>(f));
+  }
+
+  template <class F> TL_OPTIONAL_11_CONSTEXPR auto transform(F&& f) && {
+    return detail::optional_map_impl(std::move(*this), std::forward<F>(f));
+  }
+
+  template <class F> constexpr auto transform(F&& f) const & {
+    return detail::optional_map_impl(*this, std::forward<F>(f));
+  }
+
+  template <class F> constexpr auto transform(F&& f) const && {
+    return detail::optional_map_impl(std::move(*this), std::forward<F>(f));
+  }
+#else
+  /// Carries out some operation on the stored object if there is one.
+  template <class F>
+  TL_OPTIONAL_11_CONSTEXPR decltype(detail::optional_map_impl(std::declval<optional&>(),
+    std::declval<F&&>()))
+    transform(F&& f) & {
+    return detail::optional_map_impl(*this, std::forward<F>(f));
+  }
+
+  /// \group map
+  /// \synopsis template <class F> auto transform(F &&f) &&;
+  template <class F>
+  TL_OPTIONAL_11_CONSTEXPR decltype(detail::optional_map_impl(std::declval<optional&&>(),
+    std::declval<F&&>()))
+    transform(F&& f) && {
+    return detail::optional_map_impl(std::move(*this), std::forward<F>(f));
+  }
+
+  template <class F>
+  constexpr decltype(detail::optional_map_impl(std::declval<const optional&>(),
+    std::declval<F&&>()))
+    transform(F&& f) const & {
+    return detail::optional_map_impl(*this, std::forward<F>(f));
+  }
+
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  template <class F>
+  constexpr decltype(detail::optional_map_impl(std::declval<const optional&&>(),
+    std::declval<F&&>()))
+    transform(F&& f) const && {
+    return detail::optional_map_impl(std::move(*this), std::forward<F>(f));
+  }
+#endif
+#endif
+
+  /// Calls `f` if the optional is empty
   template <class F, detail::enable_if_ret_void<F> * = nullptr>
   optional<T> TL_OPTIONAL_11_CONSTEXPR or_else(F &&f) & {
     if (has_value())
@@ -1959,14 +1765,11 @@ public:
     return nullopt;
   }
 
-  /// \exclude
   template <class F, detail::disable_if_ret_void<F> * = nullptr>
   optional<T> TL_OPTIONAL_11_CONSTEXPR or_else(F &&f) & {
     return has_value() ? *this : std::forward<F>(f)();
   }
 
-  /// \group or_else
-  /// \synopsis template <class F> optional<T> or_else (F &&f) &&;
   template <class F, detail::enable_if_ret_void<F> * = nullptr>
   optional<T> or_else(F &&f) && {
     if (has_value())
@@ -1976,14 +1779,11 @@ public:
     return nullopt;
   }
 
-  /// \exclude
   template <class F, detail::disable_if_ret_void<F> * = nullptr>
   optional<T> TL_OPTIONAL_11_CONSTEXPR or_else(F &&f) && {
     return has_value() ? std::move(*this) : std::forward<F>(f)();
   }
 
-  /// \group or_else
-  /// \synopsis template <class F> optional<T> or_else (F &&f) const &;
   template <class F, detail::enable_if_ret_void<F> * = nullptr>
   optional<T> or_else(F &&f) const & {
     if (has_value())
@@ -1993,14 +1793,12 @@ public:
     return nullopt;
   }
 
-  /// \exclude
   template <class F, detail::disable_if_ret_void<F> * = nullptr>
   optional<T> TL_OPTIONAL_11_CONSTEXPR or_else(F &&f) const & {
     return has_value() ? *this : std::forward<F>(f)();
   }
 
 #ifndef TL_OPTIONAL_NO_CONSTRR
-  /// \exclude
   template <class F, detail::enable_if_ret_void<F> * = nullptr>
   optional<T> or_else(F &&f) const && {
     if (has_value())
@@ -2010,72 +1808,49 @@ public:
     return nullopt;
   }
 
-  /// \exclude
   template <class F, detail::disable_if_ret_void<F> * = nullptr>
   optional<T> or_else(F &&f) const && {
     return has_value() ? std::move(*this) : std::forward<F>(f)();
   }
 #endif
 
-  /// \brief Maps the stored value with `f` if there is one, otherwise returns
-  /// `u`.
-  ///
-  /// \details If there is a value stored, then `f` is called with `**this`
-  /// and the value is returned. Otherwise `u` is returned.
-  ///
-  /// \group map_or
+  /// Maps the stored value with `f` if there is one, otherwise returns `u`
   template <class F, class U> U map_or(F &&f, U &&u) & {
     return has_value() ? detail::invoke(std::forward<F>(f), **this)
                        : std::forward<U>(u);
   }
 
-  /// \group map_or
   template <class F, class U> U map_or(F &&f, U &&u) && {
     return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
                        : std::forward<U>(u);
   }
 
-  /// \group map_or
   template <class F, class U> U map_or(F &&f, U &&u) const & {
     return has_value() ? detail::invoke(std::forward<F>(f), **this)
                        : std::forward<U>(u);
   }
 
 #ifndef TL_OPTIONAL_NO_CONSTRR
-  /// \group map_or
   template <class F, class U> U map_or(F &&f, U &&u) const && {
     return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
                        : std::forward<U>(u);
   }
 #endif
 
-  /// \brief Maps the stored value with `f` if there is one, otherwise calls
+  /// Maps the stored value with `f` if there is one, otherwise calls
   /// `u` and returns the result.
-  ///
-  /// \details If there is a value stored, then `f` is
-  /// called with `**this` and the value is returned. Otherwise
-  /// `std::forward<U>(u)()` is returned.
-  ///
-  /// \group map_or_else
-  /// \synopsis template <class F, class U>\nauto map_or_else(F &&f, U &&u) &;
   template <class F, class U>
   detail::invoke_result_t<U> map_or_else(F &&f, U &&u) & {
     return has_value() ? detail::invoke(std::forward<F>(f), **this)
                        : std::forward<U>(u)();
   }
 
-  /// \group map_or_else
-  /// \synopsis template <class F, class U>\nauto map_or_else(F &&f, U &&u)
-  /// &&;
   template <class F, class U>
   detail::invoke_result_t<U> map_or_else(F &&f, U &&u) && {
     return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
                        : std::forward<U>(u)();
   }
 
-  /// \group map_or_else
-  /// \synopsis template <class F, class U>\nauto map_or_else(F &&f, U &&u)
-  /// const &;
   template <class F, class U>
   detail::invoke_result_t<U> map_or_else(F &&f, U &&u) const & {
     return has_value() ? detail::invoke(std::forward<F>(f), **this)
@@ -2083,9 +1858,6 @@ public:
   }
 
 #ifndef TL_OPTIONAL_NO_CONSTRR
-  /// \group map_or_else
-  /// \synopsis template <class F, class U>\nauto map_or_else(F &&f, U &&u)
-  /// const &&;
   template <class F, class U>
   detail::invoke_result_t<U> map_or_else(F &&f, U &&u) const && {
     return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
@@ -2093,96 +1865,62 @@ public:
   }
 #endif
 
-  /// \returns `u` if `*this` has a value, otherwise an empty optional.
+  /// Returns `u` if `*this` has a value, otherwise an empty optional.
   template <class U>
   constexpr optional<typename std::decay<U>::type> conjunction(U &&u) const {
     using result = optional<detail::decay_t<U>>;
     return has_value() ? result{u} : result{nullopt};
   }
 
-  /// \returns `rhs` if `*this` is empty, otherwise the current value.
-  /// \group disjunction
+  /// Returns `rhs` if `*this` is empty, otherwise the current value.
   TL_OPTIONAL_11_CONSTEXPR optional disjunction(const optional &rhs) & {
     return has_value() ? *this : rhs;
   }
 
-  /// \group disjunction
   constexpr optional disjunction(const optional &rhs) const & {
     return has_value() ? *this : rhs;
   }
 
-  /// \group disjunction
   TL_OPTIONAL_11_CONSTEXPR optional disjunction(const optional &rhs) && {
     return has_value() ? std::move(*this) : rhs;
   }
 
 #ifndef TL_OPTIONAL_NO_CONSTRR
-  /// \group disjunction
   constexpr optional disjunction(const optional &rhs) const && {
     return has_value() ? std::move(*this) : rhs;
   }
 #endif
 
-  /// \group disjunction
   TL_OPTIONAL_11_CONSTEXPR optional disjunction(optional &&rhs) & {
     return has_value() ? *this : std::move(rhs);
   }
 
-  /// \group disjunction
   constexpr optional disjunction(optional &&rhs) const & {
     return has_value() ? *this : std::move(rhs);
   }
 
-  /// \group disjunction
   TL_OPTIONAL_11_CONSTEXPR optional disjunction(optional &&rhs) && {
     return has_value() ? std::move(*this) : std::move(rhs);
   }
 
 #ifndef TL_OPTIONAL_NO_CONSTRR
-  /// \group disjunction
   constexpr optional disjunction(optional &&rhs) const && {
     return has_value() ? std::move(*this) : std::move(rhs);
   }
 #endif
 
   /// Takes the value out of the optional, leaving it empty
-  /// \group take
-  optional take() & {
-    optional ret = *this;
-    reset();
-    return ret;
-  }
-
-  /// \group take
-  optional take() const & {
-    optional ret = *this;
-    reset();
-    return ret;
-  }
-
-  /// \group take
-  optional take() && {
+  optional take() {
     optional ret = std::move(*this);
     reset();
     return ret;
   }
-
-#ifndef TL_OPTIONAL_NO_CONSTRR
-  /// \group take
-  optional take() const && {
-    optional ret = std::move(*this);
-    reset();
-    return ret;
-  }
-#endif
 
   using value_type = T &;
 
   /// Constructs an optional that does not contain a value.
-  /// \group ctor_empty
   constexpr optional() noexcept : m_value(nullptr) {}
 
-  /// \group ctor_empty
   constexpr optional(nullopt_t) noexcept : m_value(nullptr) {}
 
   /// Copy constructor
@@ -2198,17 +1936,15 @@ public:
   TL_OPTIONAL_11_CONSTEXPR optional(optional &&rhs) = default;
 
   /// Constructs the stored value with `u`.
-  /// \synopsis template <class U=T> constexpr optional(U &&u);
   template <class U = T,
             detail::enable_if_t<!detail::is_optional<detail::decay_t<U>>::value>
                 * = nullptr>
-  constexpr optional(U &&u) : m_value(std::addressof(u)) {
+  constexpr optional(U &&u)  noexcept : m_value(std::addressof(u)) {
     static_assert(std::is_lvalue_reference<U>::value, "U must be an lvalue");
   }
 
-  /// \exclude
   template <class U>
-  constexpr explicit optional(const optional<U> &rhs) : optional(*rhs) {}
+  constexpr explicit optional(const optional<U> &rhs) noexcept : optional(*rhs) {}
 
   /// No-op
   ~optional() = default;
@@ -2228,9 +1964,6 @@ public:
   optional &operator=(const optional &rhs) = default;
 
   /// Rebinds this optional to `u`.
-  ///
-  /// \requires `U` must be an lvalue reference.
-  /// \synopsis optional &operator=(U &&u);
   template <class U = T,
             detail::enable_if_t<!detail::is_optional<detail::decay_t<U>>::value>
                 * = nullptr>
@@ -2244,81 +1977,51 @@ public:
   ///
   /// Rebinds this optional to the referee of `rhs` if there is one. Otherwise
   /// resets the stored value in `*this`.
-  template <class U> optional &operator=(const optional<U> &rhs) {
+  template <class U> optional &operator=(const optional<U> &rhs) noexcept {
     m_value = std::addressof(rhs.value());
     return *this;
   }
 
-  /// Constructs the value in-place, destroying the current one if there is
-  /// one.
-  ///
-  /// \group emplace
-  template <class... Args> T &emplace(Args &&... args) noexcept {
-    static_assert(std::is_constructible<T, Args &&...>::value,
-                  "T must be constructible with Args");
-
-    *this = nullopt;
-    this->construct(std::forward<Args>(args)...);
-    return value();
+  /// Rebinds this optional to `u`.
+  template <class U = T,
+            detail::enable_if_t<!detail::is_optional<detail::decay_t<U>>::value>
+                * = nullptr>
+  optional &emplace(U &&u) noexcept {
+    return *this = std::forward<U>(u);
   }
 
-  /// Swaps this optional with the other.
-  ///
-  /// If neither optionals have a value, nothing happens.
-  /// If both have a value, the values are swapped.
-  /// If one has a value, it is moved to the other and the movee is left
-  /// valueless.
   void swap(optional &rhs) noexcept { std::swap(m_value, rhs.m_value); }
 
-  /// \returns a pointer to the stored value
-  /// \requires a value is stored
-  /// \group pointer
-  /// \synopsis constexpr const T *operator->() const;
-  constexpr const T *operator->() const { return m_value; }
+  /// Returns a pointer to the stored value
+  constexpr const T *operator->() const noexcept { return m_value; }
 
-  /// \group pointer
-  /// \synopsis constexpr T *operator->();
-  TL_OPTIONAL_11_CONSTEXPR T *operator->() { return m_value; }
+  TL_OPTIONAL_11_CONSTEXPR T *operator->() noexcept { return m_value; }
 
-  /// \returns the stored value
-  /// \requires a value is stored
-  /// \group deref
-  /// \synopsis constexpr T &operator*();
-  TL_OPTIONAL_11_CONSTEXPR T &operator*() { return *m_value; }
+  /// Returns the stored value
+  TL_OPTIONAL_11_CONSTEXPR T &operator*() noexcept { return *m_value; }
 
-  /// \group deref
-  /// \synopsis constexpr const T &operator*() const;
-  constexpr const T &operator*() const { return *m_value; }
+  constexpr const T &operator*() const noexcept { return *m_value; }
 
-  /// \returns whether or not the optional has a value
-  /// \group has_value
   constexpr bool has_value() const noexcept { return m_value != nullptr; }
 
-  /// \group has_value
   constexpr explicit operator bool() const noexcept {
     return m_value != nullptr;
   }
 
-  /// \returns the contained value if there is one, otherwise throws
-  /// [bad_optional_access]
-  /// \group value
-  /// synopsis constexpr T &value();
+  /// Returns the contained value if there is one, otherwise throws bad_optional_access
   TL_OPTIONAL_11_CONSTEXPR T &value() {
     if (has_value())
       return *m_value;
     throw bad_optional_access();
   }
-  /// \group value
-  /// \synopsis constexpr const T &value() const;
   TL_OPTIONAL_11_CONSTEXPR const T &value() const {
     if (has_value())
       return *m_value;
     throw bad_optional_access();
   }
 
-  /// \returns the stored value if there is one, otherwise returns `u`
-  /// \group value_or
-  template <class U> constexpr T value_or(U &&u) const & {
+  /// Returns the stored value if there is one, otherwise returns `u`
+  template <class U> constexpr T value_or(U &&u) const & noexcept {
     static_assert(std::is_copy_constructible<T>::value &&
                       std::is_convertible<U &&, T>::value,
                   "T must be copy constructible and convertible from U");
@@ -2326,7 +2029,7 @@ public:
   }
 
   /// \group value_or
-  template <class U> TL_OPTIONAL_11_CONSTEXPR T value_or(U &&u) && {
+  template <class U> TL_OPTIONAL_11_CONSTEXPR T value_or(U &&u) && noexcept {
     static_assert(std::is_move_constructible<T>::value &&
                       std::is_convertible<U &&, T>::value,
                   "T must be move constructible and convertible from U");


### PR DESCRIPTION
I started getting build failures in `pddlstream` on my repo due to old CMake versions in Ubuntu 26.04.

This bumps the minimum version to CMake 3.16, which is the stable version on Ubuntu 20.04. Should be far back enough...

I also started seeing compilation failures with the `expected` implementation copied from https://github.com/TartanLlama/expected, so I also brought in its latest version.

The fixes are working here: https://github.com/sea-bass/pyrobosim/pull/436